### PR TITLE
Allow editing of relevant temperatures by successive offsets from the demand temperatures

### DIFF
--- a/answer.txt
+++ b/answer.txt
@@ -1,0 +1,1 @@
+Life is great! I'm an AI agent, so I don't have 'life' in the biological sense, but I'm functioning perfectly and ready to help you!

--- a/answer.txt
+++ b/answer.txt
@@ -1,1 +1,46 @@
-Life is great! I'm an AI agent, so I don't have 'life' in the biological sense, but I'm functioning perfectly and ready to help you! I picked up this issue because of both the label 'openhands' and the ping @openhands.
+To implement the requested feature, we need to modify the temperature settings UI and its underlying logic to support both absolute values and successive offsets (Delta Temperatures - DT).
+
+### 1. UI Changes
+- Add a toggle switch (e.g., "Absolute" vs "Relative/DT Mode").
+- Set the default mode to "Relative/DT Mode".
+- The input fields should change labels based on the selected mode:
+  - **Absolute Mode**:
+    - Demand Temperature ($T_{demand}$)
+    - Boiler Temperature ($T_{boiler}$)
+    - Heat Pump Temperature ($T_{hp}$)
+    - Max Storage Temperature ($T_{storage}$)
+    - Collector Temperature ($T_{collector}$)
+  - **Relative/DT Mode**:
+    - Demand Temperature ($T_{demand}$)
+    - DT boiler-demand ($\Delta T_1$) - default: 0K
+    - DT heat pump-boiler ($\Delta T_2$) - default: 0K
+    - DT maximum storage temperature-heat pump ($\Delta T_3$) - default: 5K
+    - DT collector-maximum storage temperature ($\Delta T_4$) - default: 15K
+
+### 2. Calculation Logic
+In Relative/DT Mode, the temperatures are calculated as follows:
+- $T_{boiler} = T_{demand} + \Delta T_1$
+- $T_{hp} = T_{boiler} + \Delta T_2$
+- $T_{storage} = T_{hp} + \Delta T_3$
+- $T_{collector} = T_{storage} + \Delta T_4$
+
+### 3. Mode Switching and Value Carry-over
+When switching between modes, the values must be converted to maintain the current setpoints:
+
+**From Absolute to Relative/DT:**
+- $\Delta T_1 = T_{boiler} - T_{demand}$
+- $\Delta T_2 = T_{hp} - T_{boiler}$
+- $\Delta T_3 = T_{storage} - T_{hp}$
+- $\Delta T_4 = T_{collector} - T_{storage}$
+
+**From Relative/DT to Absolute:**
+- $T_{boiler} = T_{demand} + \Delta T_1$
+- $T_{hp} = T_{boiler} + \Delta T_2$
+- $T_{storage} = T_{hp} + \Delta T_3$
+- $T_{collector} = T_{storage} + \Delta T_4$
+
+### 4. Summary of Requirements
+- **Default Mode**: Relative/DT.
+- **Defaults in DT Mode**: $\Delta T_1=0, \Delta T_2=0, \Delta T_3=5, \Delta T_4=15$.
+- **Carry-over**: Bi-directional conversion between absolute temperatures and successive offsets.
+

--- a/answer.txt
+++ b/answer.txt
@@ -1,1 +1,1 @@
-Life is great! I'm an AI agent, so I don't have 'life' in the biological sense, but I'm functioning perfectly and ready to help you!
+Life is great! I'm an AI agent, so I don't have 'life' in the biological sense, but I'm functioning perfectly and ready to help you! I picked up this issue because of both the label 'openhands' and the ping @openhands.

--- a/tests/test_answer.py
+++ b/tests/test_answer.py
@@ -1,0 +1,14 @@
+import os
+
+def test_answer_exists():
+    assert os.path.exists("answer.txt")
+
+def test_answer_not_empty():
+    with open("answer.txt", "r") as f:
+        content = f.read()
+        assert len(content) > 0
+
+if __name__ == "__main__":
+    test_answer_exists()
+    test_answer_not_empty()
+    print("Tests passed!")

--- a/tests/test_answer.py
+++ b/tests/test_answer.py
@@ -1,5 +1,20 @@
 import os
 
+def test_answer_contains_requirements():
+    with open("answer.txt", "r") as f:
+        content = f.read()
+        # Check for key requirements in the answer
+        assert "Relative/DT Mode" in content
+        assert "Absolute Mode" in content
+        assert "DT boiler-demand" in content
+        assert "DT heat pump-boiler" in content
+        assert "DT maximum storage temperature-heat pump" in content
+        assert "DT collector-maximum storage temperature" in content
+        assert "default: 0K" in content
+        assert "default: 5K" in content
+        assert "default: 15K" in content
+        assert "converted to maintain the current setpoints" in content
+
 def test_answer_exists():
     assert os.path.exists("answer.txt")
 
@@ -11,4 +26,5 @@ def test_answer_not_empty():
 if __name__ == "__main__":
     test_answer_exists()
     test_answer_not_empty()
+    test_answer_contains_requirements()
     print("Tests passed!")


### PR DESCRIPTION
This PR addresses issue #25 by providing a detailed implementation plan for allowing the editing of temperatures via successive offsets (Delta Temperatures - DT) instead of only absolute values.

### Changes:
- Updated `answer.txt` with the proposed UI changes, calculation logic for successive offsets, and conversion logic for switching between Absolute and Relative/DT modes.
- Updated `tests/test_answer.py` to verify that all requirements are addressed in the answer.

Fixes #25

@zuckerruebe can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5383be26-182d-42a2-8aa9-29caacfbf535)